### PR TITLE
Run emit outside try...catch block

### DIFF
--- a/lib/osc.js
+++ b/lib/osc.js
@@ -298,13 +298,14 @@ var Server = function(port, host) {
         try {
             var decoded = decode(msg);
             // [<address>, <typetags>, <values>*] 
-            if (decoded) {
-                server.emit('message', decoded, rinfo);
-                server.emit(decoded[0], decoded, rinfo);
-            }
         }
         catch (e) {
             console.log("can't decode incoming message: " + e.message);
+        }
+        
+        if (decoded) {
+            server.emit('message', decoded, rinfo);
+            server.emit(decoded[0], decoded, rinfo);
         }
     });
     this.kill = function() {


### PR DESCRIPTION
Emitting the decoded messages inside the try...catch block makes it a real pain to debug downstream code. This fix makes it much easier. Thanks for the great work on this module!