### PR TITLE
throw errors not strings

### DIFF
--- a/lib/decode.js
+++ b/lib/decode.js
@@ -55,12 +55,12 @@ function decode (data) {
         typetags = typetags.value;
         // so we start building our message list
         if (typetags[0] !== ',') {
-            throw 'invalid type tag in incoming OSC message, must start with comma';
+            throw new Error('invalid type tag in incoming OSC message, must start with comma');
         }
         for (var i = 1; i < typetags.length; i++) {
             var constructor = tagToConstructor[typetags[i]];
             if (!constructor) {
-                throw 'Unsupported OSC type tag ' + typetags[i] + ' in incoming message';
+                throw new Error('Unsupported OSC type tag ' + typetags[i] + ' in incoming message');
             }
             var argument = constructor();
             data = argument.decode(data);


### PR DESCRIPTION
This is the first step of a 2 step change. Before this PR errors are assumed to be an Error object and the message property is logged. This ends up logging `undefined` when you throw a string instead of an Error.

Step 2 is a bigger change and involves passing the error to the user instead of logging it. This would require an API change though.